### PR TITLE
fix: properly (un)marshal custom time type

### DIFF
--- a/client/types.go
+++ b/client/types.go
@@ -1,6 +1,33 @@
 package client
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // DateTime is a bridge between a swagger doc "date-time" and a Golang time.Time type
-type DateTime = time.Time
+type DateTime struct {
+	time.Time
+}
+
+func (dt *DateTime) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		dt.Time = time.Time{}
+		return nil
+	}
+	parsedTime, err := time.Parse(time.DateOnly, s)
+	if err != nil {
+		return err
+	}
+	dt.Time = parsedTime
+	return nil
+}
+
+func (dt *DateTime) MarshalJSON() ([]byte, error) {
+	if dt.Time.IsZero() {
+		return []byte("null"), nil
+	}
+	return []byte(fmt.Sprintf("\"%s\"", dt.Time.Format(time.DateOnly))), nil
+}


### PR DESCRIPTION
## Description
This PR fixes the bug #3.

I tested this change locally by adding a replace directive to the `go.mod` file on my feature branch:
```
replace github.com/open-sauced/go-api/client v0.0.0-20230825180028-30fe67759eff => github.com/cecobask/go-api/client v0.0.0-20230915140043-f201131f42d3
```

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Fixes #3.
Relates to: https://github.com/open-sauced/pizza-cli/pull/38

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## Are there any post-deployment tasks we need to perform?
Release a new version of the `go-api` client.